### PR TITLE
Allow usage of different schemas for documents

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,13 +7,13 @@ services:
       - .:/app
     environment:
       - PROOPH_ENV=dev
-      - PDO_DSN=pgsql:host=postgres port=5433 dbname=event_engine
+      - PDO_DSN=pgsql:host=postgres port=5432 dbname=event_engine
       - PDO_USER=postgres
       - PDO_PWD=
 
   postgres:
     image: postgres:alpine
     ports:
-      - 5433:5432
+      - 5432:5432
     environment:
       - POSTGRES_DB=event_engine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,13 +7,13 @@ services:
       - .:/app
     environment:
       - PROOPH_ENV=dev
-      - PDO_DSN=pgsql:host=postgres port=5432 dbname=event_engine
+      - PDO_DSN=pgsql:host=postgres port=5433 dbname=event_engine
       - PDO_USER=postgres
       - PDO_PWD=
 
   postgres:
     image: postgres:alpine
     ports:
-      - 5432:5432
+      - 5433:5432
     environment:
       - POSTGRES_DB=event_engine

--- a/src/PostgresDocumentStore.php
+++ b/src/PostgresDocumentStore.php
@@ -119,6 +119,7 @@ EOT;
 SELECT TABLE_NAME 
 FROM information_schema.tables
 WHERE TABLE_NAME = '{$this->tableName($collectionName)}'
+AND TABLE_SCHEMA = '{$this->schemaName($collectionName)}'
 EOT;
 
         $stmt = $this->connection->prepare($query);
@@ -148,7 +149,7 @@ EOT;
         }
 
         $cmd = <<<EOT
-CREATE TABLE {$this->tableName($collectionName)} (
+CREATE TABLE {$this->schemaName($collectionName)}.{$this->tableName($collectionName)} (
     id {$this->docIdSchema},
     doc JSONB NOT NULL,
     $metadataColumns
@@ -751,6 +752,19 @@ EOT;
 
     private function tableName(string $collectionName): string
     {
+        if (false !== $dotPosition = strpos($collectionName, '.')) {
+            $collectionName = substr($collectionName, $dotPosition+1);
+        }
+
         return mb_strtolower($this->tablePrefix . $collectionName);
     }
+
+     private function schemaName(string $collectionName): string
+     {
+         $schemaName = 'public';
+         if (false !== $dotPosition = strpos($collectionName, '.')) {
+             $schemaName = substr($collectionName, 0, $dotPosition);
+         }
+         return mb_strtolower($schemaName);
+     }
 }

--- a/src/PostgresDocumentStore.php
+++ b/src/PostgresDocumentStore.php
@@ -148,6 +148,8 @@ EOT;
             }
         }
 
+        $createSchemaCmd = "CREATE SCHEMA IF NOT EXISTS {$this->schemaName($collectionName)}";
+
         $cmd = <<<EOT
 CREATE TABLE {$this->schemaName($collectionName)}.{$this->tableName($collectionName)} (
     id {$this->docIdSchema},
@@ -161,7 +163,8 @@ EOT;
             return $this->indexToSqlCmd($index, $collectionName);
         }, $indices);
 
-        $this->transactional(function() use ($cmd, $indicesCmds) {
+        $this->transactional(function() use ($createSchemaCmd, $cmd, $indicesCmds) {
+            $this->connection->prepare($createSchemaCmd)->execute();
             $this->connection->prepare($cmd)->execute();
 
             array_walk($indicesCmds, function ($cmd) {

--- a/src/PostgresDocumentStore.php
+++ b/src/PostgresDocumentStore.php
@@ -177,7 +177,7 @@ EOT;
     public function dropCollection(string $collectionName): void
     {
         $cmd = <<<EOT
-DROP TABLE {$this->tableName($collectionName)};
+DROP TABLE {$this->schemaName($collectionName)}.{$this->tableName($collectionName)};
 EOT;
 
         $this->transactional(function () use ($cmd) {
@@ -191,6 +191,7 @@ EOT;
 SELECT INDEXNAME 
 FROM pg_indexes
 WHERE TABLENAME = '{$this->tableName($collectionName)}'
+AND SCHEMANAME = '{$this->schemaName($collectionName)}'
 AND INDEXNAME = '$indexName'
 EOT;
 
@@ -223,7 +224,7 @@ EOT;
             $columnsSql = substr($columnsSql, 2);
 
             $metadataColumnCmd = <<<EOT
-ALTER TABLE {$this->tableName($collectionName)}
+ALTER TABLE {$this->schemaName($collectionName)}.{$this->tableName($collectionName)}
     $columnsSql;
 EOT;
 
@@ -263,7 +264,7 @@ EOT;
             $columnsSql = substr($columnsSql, 2);
 
             $metadataColumnCmd = <<<EOT
-ALTER TABLE {$this->tableName($collectionName)}
+ALTER TABLE {$this->schemaName($collectionName)}.{$this->tableName($collectionName)}
     $columnsSql;
 EOT;
             $index = $index->indexCmd();
@@ -313,7 +314,9 @@ EOT;
         }
 
         $cmd = <<<EOT
-INSERT INTO {$this->tableName($collectionName)} (id, doc{$metadataKeysStr}) VALUES (:id, :doc{$metadataValsStr});
+INSERT INTO {$this->schemaName($collectionName)}.{$this->tableName($collectionName)} (
+    id, doc{$metadataKeysStr}) VALUES (:id, :doc{$metadataValsStr}
+);
 EOT;
 
         $this->transactional(function () use ($cmd, $docId, $doc, $metadata) {
@@ -346,7 +349,7 @@ EOT;
         }
 
         $cmd = <<<EOT
-UPDATE {$this->tableName($collectionName)}
+UPDATE {$this->schemaName($collectionName)}.{$this->tableName($collectionName)}
 SET doc = (to_jsonb(doc) || :doc){$metadataStr}
 WHERE id = :id
 ;
@@ -385,7 +388,7 @@ EOT;
         }
 
         $cmd = <<<EOT
-UPDATE {$this->tableName($collectionName)}
+UPDATE {$this->schemaName($collectionName)}.{$this->tableName($collectionName)}
 SET doc = (to_jsonb(doc) || :doc){$metadataStr}
 $where;
 EOT;
@@ -425,7 +428,7 @@ EOT;
     public function deleteDoc(string $collectionName, string $docId): void
     {
         $cmd = <<<EOT
-DELETE FROM {$this->tableName($collectionName)}
+DELETE FROM {$this->schemaName($collectionName)}.{$this->tableName($collectionName)}
 WHERE id = :id
 EOT;
 
@@ -448,7 +451,7 @@ EOT;
         $where = $filterStr? "WHERE $filterStr" : '';
 
         $cmd = <<<EOT
-DELETE FROM {$this->tableName($collectionName)}
+DELETE FROM {$this->schemaName($collectionName)}.{$this->tableName($collectionName)}
 $where;
 EOT;
 
@@ -466,7 +469,7 @@ EOT;
     {
         $query = <<<EOT
 SELECT doc
-FROM {$this->tableName($collectionName)}
+FROM {$this->schemaName($collectionName)}.{$this->tableName($collectionName)}
 WHERE id = :id
 EOT;
         $stmt = $this->connection->prepare($query);
@@ -503,7 +506,7 @@ EOT;
 
         $query = <<<EOT
 SELECT doc 
-FROM {$this->tableName($collectionName)}
+FROM {$this->schemaName($collectionName)}.{$this->tableName($collectionName)}
 $where
 $orderBy
 $limit
@@ -702,7 +705,7 @@ EOT;
         $name = $index->name() ?? '';
 
         $cmd = <<<EOT
-CREATE $type $name ON {$this->tableName($collectionName)}
+CREATE $type $name ON {$this->schemaName($collectionName)}.{$this->tableName($collectionName)}
 $fields;
 EOT;
 

--- a/tests/SchemedPostgresDocumentStoreTest.php
+++ b/tests/SchemedPostgresDocumentStoreTest.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * This file is part of the event-engine/php-postgres-document-store.
+ * (c) 2019 prooph software GmbH <contact@prooph.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace EventEngine\DocumentStoreTest\Postgres;
+
+use EventEngine\DocumentStore\Filter\AnyOfDocIdFilter;
+use EventEngine\DocumentStore\Filter\AnyOfFilter;
+use EventEngine\DocumentStore\Filter\DocIdFilter;
+use EventEngine\DocumentStore\Filter\NotFilter;
+use PHPUnit\Framework\TestCase;
+use EventEngine\DocumentStore\FieldIndex;
+use EventEngine\DocumentStore\Index;
+use EventEngine\DocumentStore\MultiFieldIndex;
+use EventEngine\DocumentStore\Postgres\PostgresDocumentStore;
+use Ramsey\Uuid\Uuid;
+
+class SchemedPostgresDocumentStoreTest extends TestCase
+{
+    private CONST TABLE_PREFIX = 'test_';
+    private CONST SCHEMA = 'test.';
+
+    /**
+     * @var PostgresDocumentStore
+     */
+    protected $documentStore;
+
+    /**
+     * @var \PDO
+     */
+    protected $connection;
+
+    protected function setUp(): void
+    {
+        $this->connection = TestUtil::getConnection();
+        $this->documentStore = new PostgresDocumentStore($this->connection, self::TABLE_PREFIX);
+    }
+
+    public function tearDown(): void
+    {
+        TestUtil::tearDownDatabase();
+    }
+
+    /**
+     * @test
+     */
+    public function it_adds_collection_with_schema(): void
+    {
+        $this->documentStore->addCollection(self::SCHEMA . 'test');
+        $this->assertFalse($this->documentStore->hasCollection('test'));
+        $this->assertTrue($this->documentStore->hasCollection(self::SCHEMA . 'test'));
+    }
+}


### PR DESCRIPTION
This commit adds support for using dedicated schemas for storing
documents. This way one can separate storage of documents of different
scopes do dedicated schemas per scope. THis allows for a better
structuring of the documents within the database.

This commit does **not** handle creating the schemas. The schema needs
to be available to the DocumentStore for this to work.

Basically this allows one to set the schema right within the table-name
by separating schema and tablename by a dot like this:
`schemaname.tablename`. The name will then be split on the dot and the
former part be used as schema-name, the later part as table-name. Any
table-prefixes will only be added to the table name, not to the scheme.