### PR TITLE
Fix InArray filter for object items

### DIFF
--- a/src/PostgresDocumentStore.php
+++ b/src/PostgresDocumentStore.php
@@ -621,7 +621,7 @@ EOT;
             case DocumentStore\Filter\InArrayFilter::class:
                 /** @var DocumentStore\Filter\InArrayFilter $filter */
                 $prop = $this->propToJsonPath($filter->prop());
-                return ["$prop @> :a$argsCount", ["a$argsCount" => $this->prepareVal($filter->val(), $filter->prop())], ++$argsCount];
+                return ["$prop @> :a$argsCount", ["a$argsCount" => '[' . $this->prepareVal($filter->val(), $filter->prop()) . ']'], ++$argsCount];
             case DocumentStore\Filter\ExistsFilter::class:
                 /** @var DocumentStore\Filter\ExistsFilter $filter */
                 $prop = $this->propToJsonPath($filter->prop());

--- a/tests/SchemedPostgresDocumentStoreTest.php
+++ b/tests/SchemedPostgresDocumentStoreTest.php
@@ -43,7 +43,7 @@ class SchemedPostgresDocumentStoreTest extends TestCase
         $this->documentStore = new PostgresDocumentStore($this->connection, self::TABLE_PREFIX);
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         TestUtil::tearDownDatabase();
     }

--- a/tests/TestUtil.php
+++ b/tests/TestUtil.php
@@ -86,6 +86,7 @@ final class TestUtil
         $connection = self::getConnection();
         $statement = $connection->prepare('SELECT table_name FROM information_schema.tables WHERE table_schema = \'public\';');
         $connection->exec('DROP SCHEMA IF EXISTS prooph CASCADE');
+        $connection->exec('DROP SCHEMA IF EXISTS test CASCADE');
 
         $statement->execute();
         $tables = $statement->fetchAll(PDO::FETCH_COLUMN);


### PR DESCRIPTION
Fixes https://github.com/event-engine/php-document-store/issues/4

I've added some tests for the `InArray` filter. It worked correctly when querying for example an array of tags (string[]) but failed to filter documents that contain an array of objects with a filter that queries a subkey of the objects insight the array (see added tests for details).

The problem could be fixed by surrounding the json_encoded `InArray` filter value with square brackets. Found the solution [here](https://stackoverflow.com/a/46790476/6748089)