### PR TITLE
Implement countDocs from DocumentStore interface

### DIFF
--- a/src/PostgresDocumentStore.php
+++ b/src/PostgresDocumentStore.php
@@ -524,6 +524,29 @@ EOT;
         }
     }
 
+    /**
+     * @param string $collectionName
+     * @param Filter $filter
+     * @return int number of docs
+     */
+    public function countDocs(string $collectionName, Filter $filter): int
+    {
+        [$filterStr, $args] = $this->filterToWhereClause($filter);
+
+        $where = $filterStr? "WHERE $filterStr" : '';
+
+        $query = <<<EOT
+SELECT count(doc) 
+FROM {$this->schemaName($collectionName)}.{$this->tableName($collectionName)}
+$where;
+EOT;
+        $stmt = $this->connection->prepare($query);
+
+        $stmt->execute($args);
+
+        return (int) $stmt->fetchColumn(0);
+    }
+
     private function transactional(callable $callback)
     {
         if($this->manageTransactions) {

--- a/tests/PostgresDocumentStoreTest.php
+++ b/tests/PostgresDocumentStoreTest.php
@@ -434,6 +434,32 @@ class PostgresDocumentStoreTest extends TestCase
         $this->assertEquals([$thirdDocId], $refs);
     }
 
+    /**
+     * @test
+     */
+    public function it_counts_any_of_filter()
+    {
+        $collectionName = 'test_any_of_filter';
+        $this->documentStore->addCollection($collectionName);
+
+        $doc1 = ["foo" => "bar"];
+        $doc2 = ["foo" => "baz"];
+        $doc3 = ["foo" => "bat"];
+
+        $docs = [$doc1, $doc2, $doc3];
+
+        array_walk($docs, function (array $doc) use ($collectionName) {
+            $this->documentStore->addDoc($collectionName, Uuid::uuid4()->toString(), $doc);
+        });
+
+        $count = $this->documentStore->countDocs(
+            $collectionName,
+            new AnyOfFilter("foo", ["bar", "bat"])
+        );
+
+        $this->assertSame(2, $count);
+    }
+
     private function getIndexes(string $collectionName): array
     {
         return TestUtil::getIndexes($this->connection, self::TABLE_PREFIX.$collectionName);


### PR DESCRIPTION
This implements the countDoc feature from the DocumentStore interface so
it can be used together with the latest version of the DocumentStore.

This allows top retrieve the number of affected documents without
having to actually retrieve all the documents.