### PR TITLE
tests: confirm that (and how) associative array values are handled in updates

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - PROOPH_ENV=dev
       - PDO_DSN=pgsql:host=postgres port=5432 dbname=event_engine
       - PDO_USER=postgres
-      - PDO_PWD=
+      - PDO_PWD=test
 
   postgres:
     image: postgres:alpine
@@ -17,3 +17,4 @@ services:
       - 5432:5432
     environment:
       - POSTGRES_DB=event_engine
+      - POSTGRES_PASSWORD=test

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -22,7 +22,7 @@
     <php>
         <env name="DB_HOST" value="postgres"/>
         <env name="DB_USERNAME" value="postgres"/>
-        <env name="DB_PASSWORD" value=""/>
+        <env name="DB_PASSWORD" value="test"/>
         <env name="DB_NAME" value="event_engine"/>
         <env name="DB_PORT" value="5432"/>
         <env name="DB_CHARSET" value="utf8"/>

--- a/tests/PostgresDocumentStoreTest.php
+++ b/tests/PostgresDocumentStoreTest.php
@@ -154,6 +154,71 @@ class PostgresDocumentStoreTest extends TestCase
     /**
      * @test
      */
+    public function it_adds_and_updates_a_doc()
+    {
+        $collectionName = 'test_adds_and_updates_a_doc';
+        $this->documentStore->addCollection($collectionName);
+
+        $doc = [
+            'some' => [
+                'prop' => 'foo',
+                'other' => [
+                    'nested' => 42
+                ]
+            ],
+            'baz' => 'bat',
+        ];
+
+        $docId = Uuid::uuid4()->toString();
+        $this->documentStore->addDoc($collectionName, $docId, $doc);
+
+        $persistedDoc = $this->documentStore->getDoc($collectionName, $docId);
+
+        $this->assertEquals($doc, $persistedDoc);
+
+        $doc['baz'] = 'changed val';
+
+        $this->documentStore->updateDoc($collectionName, $docId, $doc);
+
+        $filter = new EqFilter('baz', 'changed val');
+
+        $filteredDocs = $this->documentStore->findDocs($collectionName, $filter);
+
+        $this->assertCount(1, $filteredDocs);
+    }
+
+    /**
+     * @test
+     */
+    public function it_updates_a_subset_of_a_doc()
+    {
+        $collectionName = 'test_updates_a_subset_of_a_doc';
+        $this->documentStore->addCollection($collectionName);
+
+        $doc = [
+            'some' => [
+                'prop' => 'foo',
+                'other' => 'bar'
+            ],
+            'baz' => 'bat',
+        ];
+
+        $docId = Uuid::uuid4()->toString();
+        $this->documentStore->addDoc($collectionName, $docId, $doc);
+
+        $this->documentStore->updateDoc($collectionName, $docId, [
+            'some' => [
+                'prop' => 'fuzz'
+            ]
+        ]);
+
+        $filteredDocs = array_values(iterator_to_array($this->documentStore->findDocs($collectionName, new EqFilter('some.prop', 'fuzz'))));
+        $this->assertArrayNotHasKey('other', $filteredDocs[0]['some']);
+    }
+
+    /**
+     * @test
+     */
     public function it_handles_named_indices(): void
     {
         $collectionName = 'test_named_indices';


### PR DESCRIPTION
This PR adds 2 tests:
```
it_adds_and_updates_a_doc()
it_updates_a_subset_of_a_doc()
```

This confirms that Postgres merges associative arrays but not recursively, as was possibly assumed.
https://github.com/event-engine/php-postgres-document-store/blob/e9721e21f42a648a79eb9865b5656c6949bf1c42/src/PostgresDocumentStore.php#L366

See: https://github.com/event-engine/php-document-store/issues/17 for more

(Minor note: I also had to add a test password to the postgres db to get the postgres docker container to start)