### PR TITLE
fix(deps): update event-engine/php-persistence to ^0.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,21 +16,21 @@
     }
   ],
   "require": {
-    "php": "^7.1",
+    "php": "^7.2",
     "ext-pdo": "*",
-    "event-engine/php-persistence": "^0.7"
+    "event-engine/php-persistence": "^0.8"
   },
   "require-dev": {
+    "infection/infection": "^0.15.3",
+    "malukenho/docheader": "^0.1.8",
+    "phpspec/prophecy": "^1.12.1",
+    "phpstan/phpstan": "^0.12.48",
+    "phpstan/phpstan-strict-rules": "^0.12.5",
+    "phpunit/phpunit": "^8.5.8",
+    "prooph/php-cs-fixer-config": "^0.3.1",
+    "ramsey/uuid" : "^4.1.1",
     "roave/security-advisories": "dev-master",
-    "ramsey/uuid" : "^3.6",
-    "infection/infection": "^0.11.0",
-    "malukenho/docheader": "^0.1.4",
-    "phpspec/prophecy": "^1.7",
-    "phpstan/phpstan": "^0.10.5",
-    "phpstan/phpstan-strict-rules": "^0.10.1",
-    "phpunit/phpunit": "^8.0",
-    "prooph/php-cs-fixer-config": "^0.3",
-    "satooshi/php-coveralls": "^1.0"
+    "php-coveralls/php-coveralls": "^2.2.0"
   },
   "autoload": {
     "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,7 +7,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
          bootstrap="vendor/autoload.php"
         >
     <testsuite name="prooph software Postgres Document Store for Event Engine Test Suite">


### PR DESCRIPTION
This also updates dependencies to latest PHP 7.2 compatible version, as event-engine/php-persistence requires PHP ^7.2