### PR TITLE
Allow PHP 8 (and fixed a bug)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     }
   ],
   "require": {
-    "php": "^7.2",
+    "php": "^7.2 || ^8.0",
     "ext-pdo": "*",
     "event-engine/php-persistence": "^0.8"
   },
@@ -27,7 +27,7 @@
     "phpstan/phpstan": "^0.12.48",
     "phpstan/phpstan-strict-rules": "^0.12.5",
     "phpunit/phpunit": "^8.5.8",
-    "prooph/php-cs-fixer-config": "^0.3.1",
+    "prooph/php-cs-fixer-config": "^0.4.0",
     "ramsey/uuid" : "^4.1.1",
     "roave/security-advisories": "dev-master",
     "php-coveralls/php-coveralls": "^2.2.0"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 
 services:
   php:
-    image: prooph/php:7.2-cli
+    image: prooph/php:8.0-cli
     volumes:
       - .:/app
     environment:

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * This file is part of the event-engine/php-postgres-document-store.
- * (c) 2019 prooph software GmbH <contact@prooph.de>
+ * (c) 2019-2021 prooph software GmbH <contact@prooph.de>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Exception/PostgresDocumentStoreException.php
+++ b/src/Exception/PostgresDocumentStoreException.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * This file is part of the event-engine/php-postgres-document-store.
- * (c) 2019 prooph software GmbH <contact@prooph.de>
+ * (c) 2019-2021 prooph software GmbH <contact@prooph.de>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Exception/RuntimeException.php
+++ b/src/Exception/RuntimeException.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * This file is part of the event-engine/php-postgres-document-store.
- * (c) 2019 prooph software GmbH <contact@prooph.de>
+ * (c) 2019-2021 prooph software GmbH <contact@prooph.de>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Index/RawSqlIndexCmd.php
+++ b/src/Index/RawSqlIndexCmd.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * This file is part of the event-engine/php-postgres-document-store.
+ * (c) 2019-2021 prooph software GmbH <contact@prooph.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace EventEngine\DocumentStore\Postgres\Index;

--- a/src/Metadata/Column.php
+++ b/src/Metadata/Column.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * This file is part of the event-engine/php-postgres-document-store.
+ * (c) 2019-2021 prooph software GmbH <contact@prooph.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace EventEngine\DocumentStore\Postgres\Metadata;

--- a/src/Metadata/MetadataColumnIndex.php
+++ b/src/Metadata/MetadataColumnIndex.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * This file is part of the event-engine/php-postgres-document-store.
+ * (c) 2019-2021 prooph software GmbH <contact@prooph.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace EventEngine\DocumentStore\Postgres\Metadata;

--- a/src/PostgresDocumentStore.php
+++ b/src/PostgresDocumentStore.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * This file is part of the event-engine/php-postgres-document-store.
- * (c) 2019 prooph software GmbH <contact@prooph.de>
+ * (c) 2019-2021 prooph software GmbH <contact@prooph.de>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -827,7 +827,7 @@ EOT;
                 if($innerFilter instanceof DocumentStore\Filter\AnyOfFilter || $innerFilter instanceof DocumentStore\Filter\AnyOfDocIdFilter) {
                     if ($argsCount === 0) {
                         return [
-                            substr_replace(' 1 != 1 ', ' 1 = 1 ', $innerFilterStr),
+                            str_replace(' 1 != 1 ', ' 1 = 1 ', $innerFilterStr),
                             $args,
                             $argsCount
                         ];

--- a/tests/MetadataPostgresDocumentStoreTest.php
+++ b/tests/MetadataPostgresDocumentStoreTest.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * This file is part of the event-engine/php-postgres-document-store.
+ * (c) 2019-2021 prooph software GmbH <contact@prooph.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace EventEngine\DocumentStoreTest\Postgres;

--- a/tests/PostgresDocumentStoreTest.php
+++ b/tests/PostgresDocumentStoreTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * This file is part of the event-engine/php-postgres-document-store.
- * (c) 2019 prooph software GmbH <contact@prooph.de>
+ * (c) 2019-2021 prooph software GmbH <contact@prooph.de>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/SchemedPostgresDocumentStoreTest.php
+++ b/tests/SchemedPostgresDocumentStoreTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * This file is part of the event-engine/php-postgres-document-store.
- * (c) 2019 prooph software GmbH <contact@prooph.de>
+ * (c) 2019-2021 prooph software GmbH <contact@prooph.de>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/TestUtil.php
+++ b/tests/TestUtil.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * This file is part of the event-engine/php-postgres-document-store.
- * (c) 2019 prooph software GmbH <contact@prooph.de>
+ * (c) 2019-2021 prooph software GmbH <contact@prooph.de>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.


### PR DESCRIPTION
- Allow PHP 8
- Updated (dev) dependencies
- Updated doc header with copyright year
 - Bugfix: replaced substr_replace with str_replace

https://github.com/event-engine/php-postgres-document-store/pull/19/files#diff-ad1ae52731163ed5a6715e9d147add200190335b38be36753cbc0c43e5689e73L830
```diff
- substr_replace(' 1 != 1 ', ' 1 = 1 ', $innerFilterStr),
+ str_replace(' 1 != 1 ', ' 1 = 1 ', $innerFilterStr),
```

This might affect #18, but that is purely based on looking at the code.